### PR TITLE
numerical instability due to magnitude of values - resolves #11

### DIFF
--- a/labs/01_initial_notebook/01_initial_notebook.ipynb
+++ b/labs/01_initial_notebook/01_initial_notebook.ipynb
@@ -633,7 +633,7 @@
    "source": [
     "y_pred = model.predict(x_test)\n",
     "flat_list_pred = [float('%.1f'%(item)) for sublist in y_pred for item in sublist]\n",
-    "flat_list_test = [float('%.1f'%(item)) for sublist in y_test for item in sublist]\n",
+    "flat_list_test = [float('%.1f'%(item)) for item in y_test]\n",
     "test_result = pd.DataFrame({'Predicted':flat_list_pred,'Actual':flat_list_test})\n",
     "test_result\n",
     "fig= plt.figure(figsize=(16,8))\n",

--- a/labs/01_initial_notebook/01_initial_notebook.ipynb
+++ b/labs/01_initial_notebook/01_initial_notebook.ipynb
@@ -310,14 +310,23 @@
    },
    "outputs": [],
    "source": [
-    "df['medianIncome']=np.log1p(df['medianIncome'])\n",
-    "df['housingMedianAge']=np.log1p(df['housingMedianAge'])\n",
-    "df['totalRooms']=np.log1p(df['totalRooms'])\n",
-    "df['totalBedrooms']=np.log1p(df['totalBedrooms'])\n",
-    "df['population']=np.log1p(df['population'])\n",
-    "df['households']=np.log1p(df['households'])\n",
-    "df['medianHouseValue']=np.log1p(df['medianHouseValue'])\n",
-    "df.hist(figsize=(12, 10), bins=50, edgecolor=\"black\")\n",
+    "columns_to_normalize = [\n",
+    "    'medianIncome', 'housingMedianAge', 'totalRooms', \n",
+    "    'totalBedrooms', 'population', 'households', 'medianHouseValue'\n",
+    "]\n",
+    "\n",
+    "for column in columns_to_normalize:\n",
+    "    df[column] = np.log1p(df[column])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bbdc33e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.hist(figsize=(12, 10), bins=50, edgecolor=\"black\", grid=False)\n",
     "plt.subplots_adjust(hspace=0.7, wspace=0.4)"
    ]
   },
@@ -391,8 +400,8 @@
    },
    "outputs": [],
    "source": [
-    "X = df[['DistanceToSF','DistanceToLA','housingMedianAge','totalRooms','totalBedrooms','population','households','medianIncome']]\n",
-    "Y = df[['medianHouseValue']]"
+    "X = df.drop(\"medianHouseValue\", axis=1)\n",
+    "Y = df[\"medianHouseValue\"].copy()"
    ]
   },
   {

--- a/labs/02_manual_sagemaker_process_train/02_manual_sagemaker_process_train.ipynb
+++ b/labs/02_manual_sagemaker_process_train/02_manual_sagemaker_process_train.ipynb
@@ -153,13 +153,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "columns_to_normalize = [\n",
+    "    'medianIncome', 'housingMedianAge', 'totalRooms', \n",
+    "    'totalBedrooms', 'population', 'households', 'medianHouseValue'\n",
+    "]\n",
+    "\n",
+    "for column in columns_to_normalize:\n",
+    "    df[column] = np.log1p(df[column])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "X = df[['longitude','latitude','housingMedianAge','totalRooms','totalBedrooms','population','households','medianIncome']]\n",
-    "Y = df[['medianHouseValue']]"
+    "X = df.drop(\"medianHouseValue\", axis=1)\n",
+    "Y = df[\"medianHouseValue\"].copy()"
    ]
   },
   {

--- a/labs/04_model_monitor/04_model_monitor.ipynb
+++ b/labs/04_model_monitor/04_model_monitor.ipynb
@@ -228,13 +228,28 @@
   {
    "cell_type": "code",
    "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "columns_to_normalize = [\n",
+    "    'medianIncome', 'housingMedianAge', 'totalRooms', \n",
+    "    'totalBedrooms', 'population', 'households', 'medianHouseValue'\n",
+    "]\n",
+    "\n",
+    "for column in columns_to_normalize:\n",
+    "    df[column] = np.log1p(df[column])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {
     "tags": []
    },
    "outputs": [],
    "source": [
-    "X = df[['longitude','latitude','housingMedianAge','totalRooms','totalBedrooms','population','households','medianIncome']]\n",
-    "Y = df[['medianHouseValue']]"
+    "X = df.drop(\"medianHouseValue\", axis=1)\n",
+    "Y = df[\"medianHouseValue\"].copy()"
    ]
   },
   {


### PR DESCRIPTION
this commit fixes #11

added log1p on notebooks 1,2,4

```python
columns_to_normalize = [
    'medianIncome', 'housingMedianAge', 'totalRooms', 
    'totalBedrooms', 'population', 'households', 'medianHouseValue'
]

for column in columns_to_normalize:
    df[column] = np.log1p(df[column])
```


```python
X = df.drop("medianHouseValue", axis=1)
Y = df["medianHouseValue"].copy()
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
