### PR TITLE
Fix model saving by creating directory and using .keras extension

### DIFF
--- a/labs/01_initial_notebook/01_initial_notebook.ipynb
+++ b/labs/01_initial_notebook/01_initial_notebook.ipynb
@@ -579,7 +579,8 @@
    },
    "outputs": [],
    "source": [
-    "model.save('model' + '/1')"
+    "os.makedirs('model', exist_ok=True)\n",
+    "model.save('model/1.keras')"
    ]
   },
   {
@@ -614,7 +615,7 @@
     "import numpy as np\n",
     "import tensorflow as tf\n",
     "\n",
-    "model = tf.keras.models.load_model('model/1')\n",
+    "model = tf.keras.models.load_model('model/1.keras')\n",
     "\n",
     "x_test = np.load(os.path.join(test_dir, 'x_test.npy'))\n",
     "y_test = np.load(os.path.join(test_dir, 'y_test.npy'))\n",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
While running this step `model.save('model' + '/1')` we get the following error:
```python
ValueError                                Traceback (most recent call last)
/home/sagemaker-user/amazon-sagemaker-mlops-workshop/labs/01_initial_notebook/01_initial_notebook.ipynb Cell 40 line 1
----> 1 model.save('model' + '/1')

File /opt/conda/lib/python3.11/site-packages/keras/src/utils/traceback_utils.py:122, in filter_traceback.<locals>.error_handler(*args, **kwargs)
    119     filtered_tb = _process_traceback_frames(e.__traceback__)
    120     # To get the full stack trace, call:
    121     # `keras.config.disable_traceback_filtering()`
--> 122     raise e.with_traceback(filtered_tb) from None
    123 finally:
    124     del filtered_tb

File /opt/conda/lib/python3.11/site-packages/keras/src/saving/saving_api.py:114, in save_model(model, filepath, overwrite, zipped, **kwargs)
    110 if str(filepath).endswith((".h5", ".hdf5")):
    111     return legacy_h5_format.save_model_to_hdf5(
    112         model, filepath, overwrite, include_optimizer
    113     )
--> 114 raise ValueError(
    115     "Invalid filepath extension for saving. "
    116     "Please add either a `.keras` extension for the native Keras "
    117     f"format (recommended) or a `.h5` extension. "
    118     "Use `model.export(filepath)` if you want to export a SavedModel "
    119     "for use with TFLite/TFServing/etc. "
    120     f"Received: filepath={filepath}."
    121 )

ValueError: Invalid filepath extension for saving. Please add either a `.keras` extension for the native Keras format (recommended) or a `.h5` extension. Use `model.export(filepath)` if you want to export a SavedModel for use with TFLite/TFServing/etc. Received: filepath=model/1
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
